### PR TITLE
Update build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,9 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+          path: |
+            **/node_modules
+          key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('**/package.json') }}
 
       - name: Install
         if: ${{ steps.cache-modules.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
+          # test
           path: |
             **/node_modules
           key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
-          # test
           path: |
             **/node_modules
           key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
 
       - name: Install
-        if: steps.cache-modules.output.cache-hit != 'true'
+        if: ${{ steps.cache-modules.outputs.cache-hit != 'true' }}
         run: npm install
 
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: 16.x
+  NODE_VERSION: 18.x
 
 jobs:
   bump-version:
@@ -16,14 +16,14 @@ jobs:
       tag-name: ${{ steps.lib-bump.outputs.newTag }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # This is a public_repo Github personal access token.
           token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
       - name: Bump version
         id: lib-bump
-        uses: phips28/gh-action-bump-version@v9.1.0
+        uses: phips28/gh-action-bump-version@v11.0.4
         with:
           tag-prefix: 'v'
           commit-message: '[CI/CD]: bump to {{version}}'
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.bump-version.outputs.tag-name }}
 
       - name: Use node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -58,7 +58,7 @@ jobs:
         run: npx @vscode/vsce publish -p ${{ secrets.MARKETPLACE_TOKEN }} --no-git-tag-version
 
       - name: Release on Github
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: '*.vsix'
           tag_name: ${{ needs.bump-version.outputs.tag-name }}


### PR DESCRIPTION
Some issues are reported on the workflows:

- The workflows were executed on old Node versions. Solution is to only use Node version 18 and 20
- Old versions of actions were used. Solution is to use the latest versions

After installing VSCode Github Actions extension it appeared that the logic to cache node_modules was incorrect so that is now also fixed (and verified)